### PR TITLE
Update Node.js and use centralized asset URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 # Use Node.js slim image as the base for the build stage
-FROM node:20.10.0-slim AS build-stage
+FROM node:24.11.1-slim AS build-stage
 
 # Set the working directory in the container
 WORKDIR /app
 
+# Update npm version
+RUN npm install -g npm@11.6.4
+
 # Copy package.json and package-lock.json to install dependencies
 COPY package*.json ./
+
 # Install all dependencies
 RUN npm ci
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/src/assets/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="https://storage.googleapis.com/little-pequi/assets/favicon.ico" />
     <link
             rel="stylesheet"
             href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"

--- a/src/components/LpBanner/LpBanner.tsx
+++ b/src/components/LpBanner/LpBanner.tsx
@@ -3,11 +3,10 @@ import Stack from "@mui/material/Stack"
 import Typography from "@mui/material/Typography";
 import {css} from "@emotion/react";
 import {Link} from "react-router";
-import restaurant from "../../assets/home/restaurant_inside.jpg";
 import './LpBanner.css'
 
 const banner = css({
-    backgroundImage: `linear-gradient(0deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.8)), url(${restaurant})`
+    backgroundImage: `linear-gradient(0deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.8)), url(https://storage.googleapis.com/little-pequi/assets/restaurant_inside.jpg)`
 })
 
 

--- a/src/components/LpFooter/LpFooter.tsx
+++ b/src/components/LpFooter/LpFooter.tsx
@@ -1,6 +1,5 @@
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import logoFooter from "../../assets/home/logo_footer.png";
 import LpImage from "../LpImage/LpImage.tsx";
 
 
@@ -19,7 +18,7 @@ const LpFooter = () => {
                     xs: "12%",
                     md: "2.5%"
                 }
-            }} src={logoFooter} alt="Little Pequi Logo"/>
+            }} src={"https://storage.googleapis.com/little-pequi/assets/logo_footer.png"} alt="Little Pequi Logo"/>
 
             <Typography sx={{
                 borderTop: '#333333',

--- a/src/components/LpHeader/LpHeader.tsx
+++ b/src/components/LpHeader/LpHeader.tsx
@@ -1,5 +1,4 @@
 import Container from "@mui/material/Container";
-import logo from "../../assets/logo.png";
 import LpImage from "../LpImage/LpImage.tsx";
 
 
@@ -12,7 +11,7 @@ const LpHeader = () => {
                     xs: "50%",
                     md: "20%",
                 }
-            }} src={logo} alt="Little Pequi Logo"/>
+            }} src={"https://storage.googleapis.com/little-pequi/assets/logo.png"} alt="Little Pequi Logo"/>
         </Container>
     )
 }

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -2,8 +2,6 @@ import Container from "@mui/material/Container";
 import Grid from "@mui/material/Grid";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import muiTS from "../../assets/about/muiTS.png";
-import pequiJPG from "../../assets/about/pequi.jpg";
 import LpImage from "../../components/LpImage/LpImage.tsx";
 
 const About = () => {
@@ -13,7 +11,7 @@ const About = () => {
                 <Grid container spacing={3}>
                     <Grid container direction={"column"} size={4} justifyContent={"center"}>
                         <LpImage
-                            src={pequiJPG}
+                            src={"https://storage.googleapis.com/little-pequi/assets/pequi.jpg"}
                             alt="Real Pequi photo"
                             sx={{
                                 width: "100%",
@@ -57,7 +55,7 @@ const About = () => {
                         </Typography>
                     </Grid>
                     <Grid container direction={"column"} size={4} justifyContent={"center"}>
-                        <LpImage src={muiTS}
+                        <LpImage src={"https://storage.googleapis.com/little-pequi/assets/muiTS.png"}
                                  alt="MUI TypeScript"
                                  sx={{
                                      width: "100%",

--- a/src/pages/Auth/BaseAuthPage.tsx
+++ b/src/pages/Auth/BaseAuthPage.tsx
@@ -4,7 +4,6 @@ import Container from "@mui/material/Container";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import Card from "@mui/material/Card";
-import logoFooter from "../../assets/home/logo_footer.png";
 
 const LogoIcon = styled('img')({
     width: 'auto',
@@ -35,7 +34,7 @@ const BaseAuthPage = () => {
                         <LogoIcon sx={{
                             mr: ".5rem",
                             maxWidth: '20%',
-                        }} src={logoFooter} alt="Real Pequi photo"/>
+                        }} src={"https://storage.googleapis.com/little-pequi/assets/logo_footer.png"} alt="Real Pequi photo"/>
                         <Typography variant="h4" sx={{alignSelf: 'center'}}>Little Pequi</Typography>
                     </Box>
                     <Outlet/>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -4,9 +4,6 @@ import List from "@mui/material/List"
 import ListItem from "@mui/material/ListItem"
 import ListItemText from "@mui/material/ListItemText"
 import Stack from "@mui/material/Stack";
-import headChef from "../../assets/home/head_chef.jpg";
-import salad from "../../assets/home/salad.jpg";
-import grill from "../../assets/home/grill.jpg";
 import LpBanner from "../../components/LpBanner/LpBanner.tsx";
 import LpCard from "../../components/LpCard/LpCard.tsx";
 
@@ -22,7 +19,7 @@ const App = () => {
                     sx={{marginTop: '1rem', marginBottom: '1rem'}}>
                     <LpCard
                         title={"Grilled mediterranean dishes"}
-                        image={grill}
+                        image={"https://storage.googleapis.com/little-pequi/assets/Grill.jpg"}
                         imageAlt={"Grilled Mediterranean dishes"}
                         description={"The best dishes in town!"}
                         link={"/menu"}
@@ -30,7 +27,7 @@ const App = () => {
                         mediaHeight={"15rem"}/>
                     <LpCard
                         title={"Book a table"}
-                        image={salad}
+                        image={"https://storage.googleapis.com/little-pequi/assets/salad.jpg"}
                         imageAlt={"Fresh Mediterranean salad"}
                         description={"Reserve your table for an Italian, Greek, and Turkish dining experience."}
                         link={"/reservations"}
@@ -38,7 +35,7 @@ const App = () => {
                         mediaHeight={"15rem"}/>
                     <LpCard
                         title={"Opening Hours"}
-                        image={headChef}
+                        image={"https://storage.googleapis.com/little-pequi/assets/head_chef.jpg"}
                         imageAlt={"Little Pequi restaurant head chef"}
                         description={"The Little Pequi Restaurant is open 7 days a week, except for public holidays."}
                         mediaHeight={"15rem"}>

--- a/src/pages/MakeOrder/MakeOrder.tsx
+++ b/src/pages/MakeOrder/MakeOrder.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
-import underConstruction from "../../assets/under_construction.jpg";
 import LpImage from "../../components/LpImage/LpImage.tsx";
 
 const MakeOrder = () => {
@@ -12,7 +11,7 @@ const MakeOrder = () => {
                 <Box sx={{
                     textAlign: "center",
                 }}>
-                    <LpImage src={underConstruction} alt="Page Under Construction"/>
+                    <LpImage src={"https://storage.googleapis.com/little-pequi/assets/under_construction.jpg"} alt="Page Under Construction"/>
                 </Box>
             </Container>
         </>

--- a/src/pages/Menu/Menu.tsx
+++ b/src/pages/Menu/Menu.tsx
@@ -4,7 +4,6 @@ import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import {useEffect, useState} from "react";
-import underConstruction from "../../assets/under_construction.jpg";
 import LpCard from "../../components/LpCard/LpCard.tsx";
 import LpImage from "../../components/LpImage/LpImage.tsx";
 import apiClient from "../../http";
@@ -48,7 +47,7 @@ const RestaurantMenu = () => {
                 {!categories.length && <Box sx={{
                     textAlign: "center",
                 }}>
-                    <LpImage src={underConstruction} alt="Page Under Construction"/>
+                    <LpImage src={"https://storage.googleapis.com/little-pequi/assets/under_construction.jpg"} alt="Page Under Construction"/>
                 </Box>}
             </Container>
 

--- a/src/pages/Reservations/index.tsx
+++ b/src/pages/Reservations/index.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
-import underConstruction from "../../assets/under_construction.jpg";
 import LpImage from "../../components/LpImage/LpImage.tsx";
 
 const Reservations = () => {
@@ -12,7 +11,7 @@ const Reservations = () => {
                 <Box sx={{
                     textAlign: "center",
                 }}>
-                    <LpImage src={underConstruction} alt="Page Under Construction"/>
+                    <LpImage src={"https://storage.googleapis.com/little-pequi/assets/under_construction.jpg"} alt="Page Under Construction"/>
 
                 </Box>
             </Container>

--- a/src/pages/User/UserOrder.tsx
+++ b/src/pages/User/UserOrder.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
-import underConstruction from "../../assets/under_construction.jpg";
 import LpImage from "../../components/LpImage/LpImage.tsx";
 
 const UserOrder = () => {
@@ -12,7 +11,7 @@ const UserOrder = () => {
                 <Box sx={{
                     textAlign: "center",
                 }}>
-                    <LpImage src={underConstruction} alt="Page Under Construction"/>
+                    <LpImage src={"https://storage.googleapis.com/little-pequi/assets/under_construction.jpg"} alt="Page Under Construction"/>
                 </Box>
             </Container>
         </>


### PR DESCRIPTION
### Summary

- Updated **Node.js** to `24.11.1-slim` and **npm** to `11.6.4` in the `Dockerfile` for better performance and security.
- Replaced local asset imports with URLs hosted on **Google Cloud Storage** to ensure centralized management and consistency across asset utilization.