### PR TITLE
Enhance authentication and token management- #12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Generate short SHA for Docker image tagging
       - name: Set short git commit SHA
@@ -38,7 +38,7 @@ jobs:
 
       # Authenticate with GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
 
       # Build and push Docker image
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/test-frontend.yaml
+++ b/.github/workflows/test-frontend.yaml
@@ -14,11 +14,11 @@ jobs:
     steps:
       # Check out the repository code
       - name: Checkout branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Set up a Node.js environment with a specific version
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 *.sw?
 
 *storybook.log
+.claude

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@mui/x-charts": "^8.10.0",
         "@mui/x-data-grid": "^8.7.0",
         "axios": "^1.9.0",
+        "jwt-decode": "^4.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.60.0",
@@ -5654,6 +5655,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@mui/x-charts": "^8.10.0",
     "@mui/x-data-grid": "^8.7.0",
     "axios": "^1.9.0",
+    "jwt-decode": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.60.0",

--- a/src/components/LpBackdrop/LpBackdrop.tsx
+++ b/src/components/LpBackdrop/LpBackdrop.tsx
@@ -8,11 +8,11 @@ import IAlert from "../../interfaces/IAlert.ts";
 
 interface ILpBackdropProps {
     isLoading: boolean;
-     alertState: IAlert;
-     closeAlert: () => void;
+    alertState: IAlert;
+    closeAlert: () => void;
 }
 
-const LpBackdrop = (props:ILpBackdropProps) => {
+const LpBackdrop = (props: ILpBackdropProps) => {
     const {isLoading, alertState, closeAlert} = props
 
     return (
@@ -38,7 +38,7 @@ const LpBackdrop = (props:ILpBackdropProps) => {
                     alertState.open ? closeAlert : () => {
                     }
                 }
-                sx={(theme) =>(
+                sx={(theme) => (
                     {color: '#fff', zIndex: theme.zIndex.drawer + 1}
                 )}>
                 <CircularProgress/>

--- a/src/components/LpDataGrid/DataGridToolBar.tsx
+++ b/src/components/LpDataGrid/DataGridToolBar.tsx
@@ -10,6 +10,7 @@ import DataGridQuickFilter from "./DataGridQuickFilter.tsx";
 interface IDataGridToolBarProps {
     gridTitle: string;
     showFilter?: boolean;
+    reorder?: boolean;
     onClick?: (form: "inputForm" | "displayOrder") => void;
     addButtonToolTip?: string;
     reorderButtonToolTip?: string;
@@ -17,7 +18,7 @@ interface IDataGridToolBarProps {
 
 
 const DataGridToolBar = (props: IDataGridToolBarProps) => {
-    const {gridTitle, showFilter, onClick, addButtonToolTip, reorderButtonToolTip} = props;
+    const {gridTitle, showFilter, reorder, onClick, addButtonToolTip, reorderButtonToolTip} = props;
 
     return (
         <Toolbar>
@@ -36,7 +37,7 @@ const DataGridToolBar = (props: IDataGridToolBarProps) => {
                     }}>
                     </ToolbarButton>
                 </Tooltip>}
-            {(reorderButtonToolTip && onClick) &&
+            {(reorder && onClick) &&
                 <Tooltip title={reorderButtonToolTip}>
                     <ToolbarButton render={(triggerProps) => {
                         const {color: _, ...props} = triggerProps;

--- a/src/components/LpList/LpListReorderDialog.tsx
+++ b/src/components/LpList/LpListReorderDialog.tsx
@@ -19,7 +19,7 @@ import {useReducer} from "react";
 import {MouseEvent, SetStateAction} from "react";
 import {Dispatch} from "react";
 import {useState} from "react";
-import apiClient from "../../http";
+import {apiClient} from "../../http";
 import IAction from "../../interfaces/IAction.ts";
 import IAlert from "../../interfaces/IAlert.ts";
 import IListItem from "../../interfaces/IListItem.ts";

--- a/src/components/LpNavBar/MenuUser/MenuUser.tsx
+++ b/src/components/LpNavBar/MenuUser/MenuUser.tsx
@@ -8,13 +8,14 @@ import Typography from "@mui/material/Typography";
 import {MouseEvent, useState} from "react";
 import {useNavigate} from "react-router";
 import {useAuth} from "../../../context/auth/AuthContext.ts";
+import {tokenStore} from "../../../http/auth.ts";
 
 
 const MenuUser = () => {
     const [anchorElUser, setAnchorElUser] = useState<null | HTMLElement>(null);
     const {isAdmin, setIsAdmin, setIsSignedIn} = useAuth();
     const navigate = useNavigate();
-    const user = JSON.parse(sessionStorage.getItem('user') || '{"first_name": "Anonymous"}');
+    const user = JSON.parse(tokenStore.getUser() || '{"first_name": "Anonymous"}');
 
     const handleOpenUserMenu = (event: MouseEvent<HTMLElement>) => {
         setAnchorElUser(event.currentTarget);
@@ -38,8 +39,7 @@ const MenuUser = () => {
                 navigate('/user/order');
                 break;
             case 'Logout':
-                sessionStorage.removeItem('token');
-                sessionStorage.removeItem('user');
+                tokenStore.clear();
                 setIsSignedIn(false)
                 setIsAdmin(false);
                 break;

--- a/src/components/LpNavBar/MenuUser/MenuUser.tsx
+++ b/src/components/LpNavBar/MenuUser/MenuUser.tsx
@@ -8,14 +8,12 @@ import Typography from "@mui/material/Typography";
 import {MouseEvent, useState} from "react";
 import {useNavigate} from "react-router";
 import {useAuth} from "../../../context/auth/AuthContext.ts";
-import {tokenStore} from "../../../http/auth.ts";
 
 
 const MenuUser = () => {
     const [anchorElUser, setAnchorElUser] = useState<null | HTMLElement>(null);
-    const {isAdmin, setIsAdmin, setIsSignedIn} = useAuth();
+    const {isAdmin, user, logout} = useAuth();
     const navigate = useNavigate();
-    const user = JSON.parse(tokenStore.getUser() || '{"first_name": "Anonymous"}');
 
     const handleOpenUserMenu = (event: MouseEvent<HTMLElement>) => {
         setAnchorElUser(event.currentTarget);
@@ -25,7 +23,7 @@ const MenuUser = () => {
         setAnchorElUser(null);
     };
 
-    const handleClick = (event: MouseEvent<HTMLElement>) => {
+    const handleClick = async (event: MouseEvent<HTMLElement>) => {
         const selection = event.currentTarget.textContent;
         handleCloseUserMenu();
         switch (selection) {
@@ -39,9 +37,8 @@ const MenuUser = () => {
                 navigate('/user/order');
                 break;
             case 'Logout':
-                tokenStore.clear();
-                setIsSignedIn(false)
-                setIsAdmin(false);
+                await logout();
+                navigate('/');
                 break;
         }
     }
@@ -51,7 +48,7 @@ const MenuUser = () => {
         }}>
             <Tooltip title="Open user menu">
                 <IconButton onClick={handleOpenUserMenu} sx={{p: 0}}>
-                    <Avatar alt={user.first_name}/>
+                    <Avatar alt={user?.first_name ?? 'Anonymous'}/>
                 </IconButton>
             </Tooltip>
             <Menu

--- a/src/components/LpNavBar/MenuUser/MenuUser.tsx
+++ b/src/components/LpNavBar/MenuUser/MenuUser.tsx
@@ -12,7 +12,7 @@ import {useAuth} from "../../../context/auth/AuthContext.ts";
 
 const MenuUser = () => {
     const [anchorElUser, setAnchorElUser] = useState<null | HTMLElement>(null);
-    const {isAdmin, user, logout} = useAuth();
+    const {isAdmin, user, signOut} = useAuth();
     const navigate = useNavigate();
 
     const handleOpenUserMenu = (event: MouseEvent<HTMLElement>) => {
@@ -36,8 +36,8 @@ const MenuUser = () => {
             case 'Orders':
                 navigate('/user/order');
                 break;
-            case 'Logout':
-                await logout();
+            case 'Sign Out':
+                await signOut();
                 navigate('/');
                 break;
         }
@@ -69,6 +69,7 @@ const MenuUser = () => {
                 }}
                 open={Boolean(anchorElUser)}
                 onClose={handleCloseUserMenu}>
+                {/*This is a UI hint! Backend enforces admin endpoints.*/}
                 {isAdmin &&
                     <MenuItem onClick={handleClick}
                               sx={{
@@ -119,7 +120,7 @@ const MenuUser = () => {
                         fontSize: '1rem',
                         fontWeight: 'bolder'
                     }}>
-                        Logout
+                        Sign Out
                     </Typography>
                 </MenuItem>
             </Menu>

--- a/src/context/auth/AuthContext.ts
+++ b/src/context/auth/AuthContext.ts
@@ -6,8 +6,9 @@ export interface IAuthContextProps {
     isSignedIn: boolean;
     isAdmin: boolean;
     isAuthLoading: boolean;
-    login: (email: string, password: string) => Promise<void>;
-    logout: () => Promise<void>;
+    isBootstrapping: boolean;
+    signIn: (email: string, password: string) => Promise<void>;
+    signOut: () => Promise<void>;
 }
 
 export const AuthContext = createContext<IAuthContextProps | undefined>(undefined);

--- a/src/context/auth/AuthContext.ts
+++ b/src/context/auth/AuthContext.ts
@@ -1,10 +1,13 @@
 import {createContext, useContext} from "react";
+import IUser from "../../interfaces/IUser.ts";
 
 export interface IAuthContextProps {
+    user: IUser | null;
     isSignedIn: boolean;
-    setIsSignedIn: (value: boolean) => void;
     isAdmin: boolean;
-    setIsAdmin: (value: boolean) => void;
+    isAuthLoading: boolean;
+    login: (email: string, password: string) => Promise<void>;
+    logout: () => Promise<void>;
 }
 
 export const AuthContext = createContext<IAuthContextProps | undefined>(undefined);

--- a/src/context/auth/AuthContextProvider.tsx
+++ b/src/context/auth/AuthContextProvider.tsx
@@ -3,7 +3,7 @@ import {ReactNode, useState} from "react";
 import {IAuthContextProps} from "./AuthContext";
 import {AuthContext} from "./AuthContext";
 import {authChannel, AuthMessage, setSignOutCallback, tokenStore} from "../../http/auth.ts";
-import apiClient from "../../http";
+import {apiClient, refreshClient} from "../../http";
 import IUser from "../../interfaces/IUser.ts";
 import {AxiosError, isAxiosError} from "axios";
 
@@ -35,24 +35,20 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
             setUser(null);
         });
 
-        const token = tokenStore.getAccess();
-        if (!token) {
-            setIsBootstrapping(false);
+        refreshClient.post<{ access: string }>('/auth/refresh/')
+        .then(response => {
+            tokenStore.setAccess(response.data.access);
+            return apiClient.get<IUser>('/auth/users/me/');
+        })
+        .then(response => setUser(response.data))
+        .catch(() => {
+            // No valid refresh cookie → signed out. Expected on first visit.
+            tokenStore.clear();
+        })
+        .finally(() => {
+            setIsBootstrapping(false)
             setIsAuthLoading(false);
-            return;
-        }
-        apiClient.get<IUser>('/auth/users/me/')
-            .then(res => {
-                setUser(res.data);
-            })
-            .catch(err => {
-                console.log(err);
-                tokenStore.clear();
-            })
-            .finally(() => {
-                setIsAuthLoading(false);
-                setIsBootstrapping(false);
-            })
+        });
     }, []);
 
     const isSignedIn = user !== null;
@@ -62,8 +58,8 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
         setIsAuthLoading(true);
         try {
             const {data} = await apiClient.post("/auth/sign-in/", {email, password});
+
             tokenStore.setAccess(data.access);
-            tokenStore.setRefresh(data.refresh);
             const me = await apiClient.get<IUser>("/auth/users/me/");
             setUser(me.data);
         } catch (error) {
@@ -84,7 +80,6 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
 
     const signOut = useCallback(async () => {
         try {
-            // const refreshToken = tokenStore.getRefresh();
             const response = await apiClient.post('/auth/sign-out/');
             console.log(response.data);
         } catch (error) {

--- a/src/context/auth/AuthContextProvider.tsx
+++ b/src/context/auth/AuthContextProvider.tsx
@@ -2,22 +2,22 @@ import {useMemo} from "react";
 import {ReactNode, useState} from "react";
 import {IAuthContextProps} from "./AuthContext";
 import {AuthContext} from "./AuthContext";
+import {decodeJwt, tokenStore} from "../../http/auth.ts";
+import {JwtPayload} from "jwt-decode";
 
 export const AuthProvider = ({children}: { children: ReactNode }) => {
     // Initialize the isSignedIn state and check if there's a token in sessionStorage on an initial load
-    const token = sessionStorage.getItem('token')
-    const isUserAdmin = () => {
+    const token = tokenStore.getAccess();
+    const isUserAdmin = (): boolean => {
         if (token === null) {
+            return false;
+        }
 
-            return false;
+        const jwtPayload: JwtPayload | null = decodeJwt(token);
+        if (jwtPayload && 'admin' in jwtPayload) {
+            return jwtPayload['admin'] as boolean;
         }
-        const jwtPayload = JSON.parse(atob(token.split('.')[1]));
-        if (jwtPayload) {
-            if ('admin' in jwtPayload) {
-                return jwtPayload.admin;
-            }
-            return false;
-        }
+        return false;
     }
 
     const [isSignedIn, setIsSignedIn] = useState(token !== null)

--- a/src/context/auth/AuthContextProvider.tsx
+++ b/src/context/auth/AuthContextProvider.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useMemo} from "react";
 import {ReactNode, useState} from "react";
 import {IAuthContextProps} from "./AuthContext";
 import {AuthContext} from "./AuthContext";
-import {decodeJwt, tokenStore} from "../../http/auth.ts";
+import {decodeJwt, setLogoutCallback, tokenStore} from "../../http/auth.ts";
 import {JwtPayload} from "jwt-decode";
 import apiClient from "../../http";
 import IUser from "../../interfaces/IUser.ts";
@@ -18,20 +18,27 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
     const [user, setUser] = useState<IUser | null>(null);
 
     useEffect(() => {
+        setLogoutCallback(() => {
+            tokenStore.clear();
+            setUser(null);
+        });
+
         const token = tokenStore.getAccess();
-        if (token) {
-            apiClient.get<IUser>('/auth/users/me/')
-                .then(res => {
-                    setUser(res.data);
-                })
-                .catch(err => {
-                        console.log(err);
-                        tokenStore.clear();
-                    }
-                )
+        if (!token) {
+            setIsAuthLoading(false);
+            return;
         }
-        setIsAuthLoading(false);
-    }, [])
+        apiClient.get<IUser>('/auth/users/me/')
+            .then(res => {
+                setUser(res.data);
+            })
+            .catch(err => {
+                console.log(err);
+                tokenStore.clear();
+            })
+            .finally(() => setIsAuthLoading(false))
+    }, []);
+
     const isSignedIn = user !== null;
     const isAdmin = useMemo((): boolean => {
         const token = tokenStore.getAccess();
@@ -53,7 +60,7 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
             const me = await apiClient.get<IUser>("/auth/users/me/");
             setUser(me.data);
         } catch (error) {
-            if (isAxiosError<ApiError>(error)){
+            if (isAxiosError<ApiError>(error)) {
                 console.log(error.response?.data);
                 console.log(error.response);
                 console.error("Error during login:", error);

--- a/src/context/auth/AuthContextProvider.tsx
+++ b/src/context/auth/AuthContextProvider.tsx
@@ -1,34 +1,97 @@
-import {useMemo} from "react";
+import {useCallback, useEffect, useMemo} from "react";
 import {ReactNode, useState} from "react";
 import {IAuthContextProps} from "./AuthContext";
 import {AuthContext} from "./AuthContext";
 import {decodeJwt, tokenStore} from "../../http/auth.ts";
 import {JwtPayload} from "jwt-decode";
+import apiClient from "../../http";
+import IUser from "../../interfaces/IUser.ts";
+import {AxiosError, isAxiosError} from "axios";
+
+type ApiError = {
+    message: string;
+    code: string;
+}
 
 export const AuthProvider = ({children}: { children: ReactNode }) => {
-    // Initialize the isSignedIn state and check if there's a token in sessionStorage on an initial load
-    const token = tokenStore.getAccess();
-    const isUserAdmin = (): boolean => {
-        if (token === null) {
-            return false;
+    const [isAuthLoading, setIsAuthLoading] = useState(true);
+    const [user, setUser] = useState<IUser | null>(null);
+
+    useEffect(() => {
+        const token = tokenStore.getAccess();
+        if (token) {
+            apiClient.get<IUser>('/auth/users/me/')
+                .then(res => {
+                    setUser(res.data);
+                })
+                .catch(err => {
+                        console.log(err);
+                        tokenStore.clear();
+                    }
+                )
         }
+        setIsAuthLoading(false);
+    }, [])
+    const isSignedIn = user !== null;
+    const isAdmin = useMemo((): boolean => {
+        const token = tokenStore.getAccess();
+        if (!token) return false;
 
         const jwtPayload: JwtPayload | null = decodeJwt(token);
         if (jwtPayload && 'admin' in jwtPayload) {
             return jwtPayload['admin'] as boolean;
         }
         return false;
-    }
+    }, [user]);
 
-    const [isSignedIn, setIsSignedIn] = useState(token !== null)
-    const [isAdmin, setIsAdmin] = useState(isUserAdmin)
+    const login = async (email: string, password: string) => {
+        setIsAuthLoading(true);
+        try {
+            const {data} = await apiClient.post("/auth/sign-in/", {email, password});
+            tokenStore.setAccess(data.access);
+            tokenStore.setRefresh(data.refresh);
+            const me = await apiClient.get<IUser>("/auth/users/me/");
+            setUser(me.data);
+        } catch (error) {
+            if (isAxiosError<ApiError>(error)){
+                console.log(error.response?.data);
+                console.log(error.response);
+                console.error("Error during login:", error);
+                tokenStore.clear();
+                setUser(null);
+                throw error as AxiosError;
+            } else {
+                throw error;
+            }
+
+        } finally {
+            setIsAuthLoading(false);
+        }
+
+    };
+
+    const logout = useCallback(async () => {
+        try {
+            // const refreshToken = tokenStore.getRefresh();
+            const response = await apiClient.post('/auth/sign-out/');
+            console.log(response.data);
+        } catch (error) {
+            console.error("Error during logout:", error);
+        } finally {
+            tokenStore.clear();
+            setUser(null);
+        }
+    }, []);
+
 
     const authContext = useMemo<IAuthContextProps>(() => ({
+        user,
         isSignedIn,
-        setIsSignedIn,
         isAdmin,
-        setIsAdmin
-    }), [isSignedIn, isAdmin])
+        isAuthLoading,
+        login,
+        logout
+    }), [user, isAdmin, isAuthLoading, login, logout])
 
     return (
         <AuthContext.Provider value={authContext}>

--- a/src/context/auth/AuthContextProvider.tsx
+++ b/src/context/auth/AuthContextProvider.tsx
@@ -2,8 +2,7 @@ import {useCallback, useEffect, useMemo} from "react";
 import {ReactNode, useState} from "react";
 import {IAuthContextProps} from "./AuthContext";
 import {AuthContext} from "./AuthContext";
-import {decodeJwt, setLogoutCallback, tokenStore} from "../../http/auth.ts";
-import {JwtPayload} from "jwt-decode";
+import {authChannel, AuthMessage, setSignOutCallback, tokenStore} from "../../http/auth.ts";
 import apiClient from "../../http";
 import IUser from "../../interfaces/IUser.ts";
 import {AxiosError, isAxiosError} from "axios";
@@ -15,16 +14,30 @@ type ApiError = {
 
 export const AuthProvider = ({children}: { children: ReactNode }) => {
     const [isAuthLoading, setIsAuthLoading] = useState(true);
+    const [isBootstrapping, setIsBootstrapping] = useState(true);
     const [user, setUser] = useState<IUser | null>(null);
 
     useEffect(() => {
-        setLogoutCallback(() => {
+        const onMessage = (event: MessageEvent<AuthMessage>) => {
+            if (event.data?.type === 'signOut') {
+                tokenStore.clear();
+                setUser(null);
+            }
+        };
+        authChannel.addEventListener('message', onMessage);
+        return () => authChannel.removeEventListener('message', onMessage);
+    }, []);
+
+    // Bootstrap user data
+    useEffect(() => {
+        setSignOutCallback(() => {
             tokenStore.clear();
             setUser(null);
         });
 
         const token = tokenStore.getAccess();
         if (!token) {
+            setIsBootstrapping(false);
             setIsAuthLoading(false);
             return;
         }
@@ -36,22 +49,16 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
                 console.log(err);
                 tokenStore.clear();
             })
-            .finally(() => setIsAuthLoading(false))
+            .finally(() => {
+                setIsAuthLoading(false);
+                setIsBootstrapping(false);
+            })
     }, []);
 
     const isSignedIn = user !== null;
-    const isAdmin = useMemo((): boolean => {
-        const token = tokenStore.getAccess();
-        if (!token) return false;
+    const isAdmin = user?.is_staff ?? false;
 
-        const jwtPayload: JwtPayload | null = decodeJwt(token);
-        if (jwtPayload && 'admin' in jwtPayload) {
-            return jwtPayload['admin'] as boolean;
-        }
-        return false;
-    }, [user]);
-
-    const login = async (email: string, password: string) => {
+    const signIn = async (email: string, password: string) => {
         setIsAuthLoading(true);
         try {
             const {data} = await apiClient.post("/auth/sign-in/", {email, password});
@@ -61,9 +68,6 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
             setUser(me.data);
         } catch (error) {
             if (isAxiosError<ApiError>(error)) {
-                console.log(error.response?.data);
-                console.log(error.response);
-                console.error("Error during login:", error);
                 tokenStore.clear();
                 setUser(null);
                 throw error as AxiosError;
@@ -73,11 +77,12 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
 
         } finally {
             setIsAuthLoading(false);
+            setIsBootstrapping(false);
         }
 
     };
 
-    const logout = useCallback(async () => {
+    const signOut = useCallback(async () => {
         try {
             // const refreshToken = tokenStore.getRefresh();
             const response = await apiClient.post('/auth/sign-out/');
@@ -87,6 +92,7 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
         } finally {
             tokenStore.clear();
             setUser(null);
+            authChannel.postMessage({type: 'signOut'} satisfies AuthMessage);
         }
     }, []);
 
@@ -96,9 +102,10 @@ export const AuthProvider = ({children}: { children: ReactNode }) => {
         isSignedIn,
         isAdmin,
         isAuthLoading,
-        login,
-        logout
-    }), [user, isAdmin, isAuthLoading, login, logout])
+        isBootstrapping,
+        signIn: signIn,
+        signOut
+    }), [user, isAdmin, isAuthLoading, isBootstrapping, signIn, signOut])
 
     return (
         <AuthContext.Provider value={authContext}>

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -3,13 +3,10 @@ import {jwtDecode} from "jwt-decode";
 export const tokenStore = {
     ACCESS_KEY: "token", //Necessary?
     REFRESH_KEY: "refresh", //Necessary?
-    USER_KEY: "user", //Necessary?
     getAccess: () => sessionStorage.getItem("token"),
     getRefresh: () => sessionStorage.getItem("refresh"),
-    getUser: () => sessionStorage.getItem("user"),
     setAccess: (token: string) => sessionStorage.setItem("token", token),
     setRefresh: (token: string) => sessionStorage.setItem("refresh", token),
-    setUser: (user: string) => sessionStorage.setItem("user", user),
     clear: () => {
         sessionStorage.removeItem("token");
         sessionStorage.removeItem("refresh");

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,19 +1,15 @@
+let accessToken: string | null = null;
+
 export const tokenStore = {
-    ACCESS_KEY: "token", //Necessary?
-    REFRESH_KEY: "refresh", //Necessary?
-    getAccess: () => sessionStorage.getItem("token"),
-    getRefresh: () => sessionStorage.getItem("refresh"),
-    setAccess: (token: string) => sessionStorage.setItem("token", token),
-    setRefresh: (token: string) => sessionStorage.setItem("refresh", token),
+    getAccess: () => accessToken,
+    setAccess: (token: string) => { accessToken = token; },
     clear: () => {
-        sessionStorage.removeItem("token");
-        sessionStorage.removeItem("refresh");
+        accessToken = null;
     },
 };
 
-// May be temporary, double check after moving backend to and frontend to HTTPCookie_only
 export const authChannel = new BroadcastChannel('auth');
-export type AuthMessage = { type: 'signOut' } | { type: 'signIn' };
+export type AuthMessage = { type: 'signOut' };
 
 type SignOutCallback = () => void;
 let signOutCallback: SignOutCallback | null = null;

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,5 +1,3 @@
-import {jwtDecode} from "jwt-decode";
-
 export const tokenStore = {
     ACCESS_KEY: "token", //Necessary?
     REFRESH_KEY: "refresh", //Necessary?
@@ -13,18 +11,12 @@ export const tokenStore = {
     },
 };
 
-export const decodeJwt = <JwtPayload>(token: string): JwtPayload | null => {
-    try {
-        return jwtDecode<JwtPayload>(token);
+// May be temporary, double check after moving backend to and frontend to HTTPCookie_only
+export const authChannel = new BroadcastChannel('auth');
+export type AuthMessage = { type: 'signOut' } | { type: 'signIn' };
 
-    } catch (err) {
-        console.log(err)
-        return null;
-    }
-}
+type SignOutCallback = () => void;
+let signOutCallback: SignOutCallback | null = null;
 
-type LogoutCallback = () => void;
-let logoutCallback: LogoutCallback | null = null;
-
-export const setLogoutCallback = (callback: LogoutCallback) => logoutCallback = callback;
-export const fireLogoutCallback = () => logoutCallback?.();
+export const setSignOutCallback = (callback: SignOutCallback) => signOutCallback = callback;
+export const fireSignOutCallback = () => signOutCallback?.();

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -10,7 +10,6 @@ export const tokenStore = {
     clear: () => {
         sessionStorage.removeItem("token");
         sessionStorage.removeItem("refresh");
-        sessionStorage.removeItem("user");
     },
 };
 
@@ -23,3 +22,9 @@ export const decodeJwt = <JwtPayload>(token: string): JwtPayload | null => {
         return null;
     }
 }
+
+type LogoutCallback = () => void;
+let logoutCallback: LogoutCallback | null = null;
+
+export const setLogoutCallback = (callback: LogoutCallback) => logoutCallback = callback;
+export const fireLogoutCallback = () => logoutCallback?.();

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,28 @@
+import {jwtDecode} from "jwt-decode";
+
+export const tokenStore = {
+    ACCESS_KEY: "token", //Necessary?
+    REFRESH_KEY: "refresh", //Necessary?
+    USER_KEY: "user", //Necessary?
+    getAccess: () => sessionStorage.getItem("token"),
+    getRefresh: () => sessionStorage.getItem("refresh"),
+    getUser: () => sessionStorage.getItem("user"),
+    setAccess: (token: string) => sessionStorage.setItem("token", token),
+    setRefresh: (token: string) => sessionStorage.setItem("refresh", token),
+    setUser: (user: string) => sessionStorage.setItem("user", user),
+    clear: () => {
+        sessionStorage.removeItem("token");
+        sessionStorage.removeItem("refresh");
+        sessionStorage.removeItem("user");
+    },
+};
+
+export const decodeJwt = <JwtPayload>(token: string): JwtPayload | null => {
+    try {
+        return jwtDecode<JwtPayload>(token);
+
+    } catch (err) {
+        console.log(err)
+        return null;
+    }
+}

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,46 +1,44 @@
 import {AxiosError, AxiosInstance} from "axios";
 import axios from "axios";
-import {decodeJwt, tokenStore} from "./auth.ts";
-import {JwtPayload} from "jwt-decode";
+import {fireLogoutCallback, tokenStore} from "./auth.ts";
+
 
 
 const apiClient: AxiosInstance = axios.create({
     baseURL: import.meta.env.VITE_BACKEND_URL,
+})
 
+// Separate instance with no interceptors — used only for token refresh
+// to avoid triggering the request interceptor recursively.
+const refreshClient: AxiosInstance = axios.create({
+    baseURL: import.meta.env.VITE_BACKEND_URL,
 })
 
 // Flag to prevent multiple simultaneous refresh attempts
 let isRefreshing = false;
 
 // Queue to store failed requests while refreshing
-let failedQueue: Array<{
-    resolve: (value?: any) => void;
-    reject: (error?: any) => void;
-}> = [];
+type QueueItem = {
+    resolve: (value: string) => void;
+    reject: (error: AxiosError) => void;
+}
+let failedQueue: QueueItem[] = [];
 
 const processQueue = (error: AxiosError | null, token: string | null = null) => {
     failedQueue.forEach(({resolve, reject}) => {
-        if (error) {
-            reject(error);
-        } else {
-            resolve(token);
-        }
+        if (error) reject(error);
+        else resolve(token as string);
     });
-
     failedQueue = [];
 };
 
 const refreshToken = async (): Promise<string> => {
-    const payload = {
-        refresh: tokenStore.getRefresh(),
-    }
-    if (!payload.refresh) {
-        throw new Error('No refresh token available');
-    }
+    const refresh = tokenStore.getRefresh()
+    if (!refresh) throw new Error('No refresh token available');
 
     try {
         // Request new token
-        const response = await apiClient.post('/auth/refresh/', payload);
+        const response = await refreshClient.post('/auth/refresh/', {refresh});
 
         // Update token in session storage
         const newToken = response.data.access;
@@ -49,31 +47,42 @@ const refreshToken = async (): Promise<string> => {
         return newToken;
     } catch (error) {
         // Clear tokens on refresh failure
-        tokenStore.clear();
+        tokenStore.clear(); //Redundant?
 
-        // Redirect to sign-in or dispatch logout action
-        window.location.href = '/login';
-
+        // Fire logout callback
+        fireLogoutCallback();
         throw error;
     }
 };
 
+// Request interceptor — attaches the current access token (JWT scheme for Djoser)
+apiClient.interceptors.request.use(
+    (config) => {
+        const token = tokenStore.getAccess();
+        if (token && config.headers) {
+            config.headers.Authorization = `JWT ${token}`;
+        }
 
-// Response interceptor for handling token refresh
+        return config;
+    }, (error) => {
+        console.log(error);
+        return Promise.reject(error);
+    })
+
+// Response interceptor — refreshes on 401, queues concurrent requests
 apiClient.interceptors.response.use(response => response,
-    async (responseError) => {
-        const originalRequest = responseError.config;
-
-        if (responseError.response.status === 401 && !originalRequest._retry) {
+    async (responseError: AxiosError) => {
+        const originalRequest = responseError.config as typeof responseError.config & { _retry?: boolean };
+        if (responseError.response?.status === 401 && !originalRequest?._retry) {
             if (isRefreshing) {
                 // If already refreshing, queue this request
-                return new Promise((resolve, reject) => {
+                return new Promise<string>((resolve, reject) => {
                     failedQueue.push({resolve, reject});
                 }).then(token => {
-                    if (originalRequest.headers) {
+                    if (originalRequest?.headers) {
                         originalRequest.headers.Authorization = `JWT ${token}`;
                     }
-                    return apiClient(originalRequest);
+                    return apiClient(originalRequest!);
                 }).catch(error => {
                     return Promise.reject(error);
                 });
@@ -87,11 +96,11 @@ apiClient.interceptors.response.use(response => response,
                 const newToken = await refreshToken();
                 processQueue(null, newToken);
 
-                if (originalRequest.headers) {
+                if (originalRequest?.headers) {
                     originalRequest.headers.Authorization = `JWT ${newToken}`;
                 }
 
-                return apiClient(originalRequest);
+                return apiClient(originalRequest!);
             } catch (refreshError) {
                 console.log("Fail", refreshError)
                 processQueue(refreshError as AxiosError, null);
@@ -104,38 +113,5 @@ apiClient.interceptors.response.use(response => response,
         return Promise.reject(responseError);
     }
 )
-
-// Check if the token is expired
-const isTokenExpired = (token: string): boolean => {
-    try {
-        const payload = decodeJwt(token) as JwtPayload;
-        if (!payload.exp) {
-            return true;
-        }
-        return payload.exp * 1000 < Date.now();
-    } catch {
-        return true;
-    }
-};
-
-// Request interceptor to add token to headers
-apiClient.interceptors.request.use(
-    async (config) => {
-        let token = tokenStore.getAccess();
-
-        if (token && config.headers) {
-            if (isTokenExpired(token)) {
-                await refreshToken();
-                token = tokenStore.getAccess();
-            }
-            config.headers.Authorization = `JWT ${token}`;
-        }
-
-        return config;
-    }, (error) => {
-        console.log(error);
-        return Promise.reject(error);
-    })
-
 
 export default apiClient;

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,10 +1,10 @@
-import {AxiosError} from "axios";
+import {AxiosError, AxiosInstance} from "axios";
 import axios from "axios";
 import {decodeJwt, tokenStore} from "./auth.ts";
 import {JwtPayload} from "jwt-decode";
 
 
-const apiClient = axios.create({
+const apiClient: AxiosInstance = axios.create({
     baseURL: import.meta.env.VITE_BACKEND_URL,
 
 })

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,5 +1,7 @@
 import {AxiosError} from "axios";
 import axios from "axios";
+import {decodeJwt, tokenStore} from "./auth.ts";
+import {JwtPayload} from "jwt-decode";
 
 
 const apiClient = axios.create({
@@ -30,7 +32,7 @@ const processQueue = (error: AxiosError | null, token: string | null = null) => 
 
 const refreshToken = async (): Promise<string> => {
     const payload = {
-        refresh: sessionStorage.getItem('refresh'),
+        refresh: tokenStore.getRefresh(),
     }
     if (!payload.refresh) {
         throw new Error('No refresh token available');
@@ -42,13 +44,12 @@ const refreshToken = async (): Promise<string> => {
 
         // Update token in session storage
         const newToken = response.data.access;
-        sessionStorage.setItem('token', newToken);
+        tokenStore.setAccess(newToken);
 
         return newToken;
     } catch (error) {
         // Clear tokens on refresh failure
-        sessionStorage.removeItem('token');
-        sessionStorage.removeItem('refresh');
+        tokenStore.clear();
 
         // Redirect to sign-in or dispatch logout action
         window.location.href = '/login';
@@ -107,7 +108,10 @@ apiClient.interceptors.response.use(response => response,
 // Check if the token is expired
 const isTokenExpired = (token: string): boolean => {
     try {
-        const payload = JSON.parse(atob(token.split('.')[1]));
+        const payload = decodeJwt(token) as JwtPayload;
+        if (!payload.exp) {
+            return true;
+        }
         return payload.exp * 1000 < Date.now();
     } catch {
         return true;
@@ -117,12 +121,12 @@ const isTokenExpired = (token: string): boolean => {
 // Request interceptor to add token to headers
 apiClient.interceptors.request.use(
     async (config) => {
-        let token = sessionStorage.getItem('token');
+        let token = tokenStore.getAccess();
 
         if (token && config.headers) {
             if (isTokenExpired(token)) {
                 await refreshToken();
-                token = sessionStorage.getItem('token');
+                token = tokenStore.getAccess();
             }
             config.headers.Authorization = `JWT ${token}`;
         }

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -6,13 +6,16 @@ import {fireSignOutCallback, tokenStore} from "./auth.ts";
 
 const apiClient: AxiosInstance = axios.create({
     baseURL: import.meta.env.VITE_BACKEND_URL,
-})
+    withCredentials: true,
+});
 
 // Separate instance with no interceptors — used only for token refresh
 // to avoid triggering the request interceptor recursively.
 const refreshClient: AxiosInstance = axios.create({
     baseURL: import.meta.env.VITE_BACKEND_URL,
-})
+    withCredentials: true,
+    headers: {"X-Requested-With": "XMLHttpRequest"},
+});
 
 // Flag to prevent multiple simultaneous refresh attempts
 let isRefreshing = false;
@@ -33,12 +36,9 @@ const processQueue = (error: AxiosError | null, token: string | null = null) => 
 };
 
 const refreshToken = async (): Promise<string> => {
-    const refresh = tokenStore.getRefresh()
-    if (!refresh) throw new Error('No refresh token available');
-
     try {
         // Request new token
-        const response = await refreshClient.post('/auth/refresh/', {refresh});
+        const response = await refreshClient.post('/auth/refresh/');
 
         // Update token in session storage
         const newToken = response.data.access;
@@ -114,4 +114,4 @@ apiClient.interceptors.response.use(response => response,
     }
 )
 
-export default apiClient;
+export {apiClient, refreshClient};

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,6 +1,6 @@
 import {AxiosError, AxiosInstance} from "axios";
 import axios from "axios";
-import {fireLogoutCallback, tokenStore} from "./auth.ts";
+import {fireSignOutCallback, tokenStore} from "./auth.ts";
 
 
 
@@ -50,7 +50,7 @@ const refreshToken = async (): Promise<string> => {
         tokenStore.clear(); //Redundant?
 
         // Fire logout callback
-        fireLogoutCallback();
+        fireSignOutCallback();
         throw error;
     }
 };

--- a/src/interfaces/IAlert.ts
+++ b/src/interfaces/IAlert.ts
@@ -1,5 +1,7 @@
+import {AlertColor} from "@mui/material/Alert";
+
 interface IAlert {
-    severity: 'success' | 'error' | 'info';
+    severity: AlertColor;
     message: string;
     open: boolean;
 }

--- a/src/interfaces/IUser.ts
+++ b/src/interfaces/IUser.ts
@@ -3,6 +3,7 @@ interface IUser {
     first_name: string;
     last_name: string;
     email: string;
+    is_staff: boolean;
 }
 
 export default IUser;

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -63,10 +63,12 @@ const Admin = () => {
         </Box>
     );
     useEffect(() => {
+        if (auth.isAuthLoading) return;
         if (!auth.isAdmin || !auth.isSignedIn) {
             navigate('/auth/sign-in');
         }
-    })
+    }, [auth.isAuthLoading, auth.isAdmin, auth.isSignedIn, navigate])
+
     return (
         <>
             <Stack direction={"row"} flexDirection={"column"} sx={{my: 2, position: 'relative'}}

--- a/src/pages/Admin/Admin.tsx
+++ b/src/pages/Admin/Admin.tsx
@@ -10,18 +10,15 @@ import ListItemButton from "@mui/material/ListItemButton";
 import ListItemText from "@mui/material/ListItemText";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import {useEffect} from "react";
 import {useState} from "react";
 import {useNavigate} from "react-router";
 import {Outlet} from "react-router"
-import {useAuth} from "../../context/auth/AuthContext.ts";
 import CrudAdminContextProvider from "./context/CrudAdminContextProvider.tsx";
 
 
 const Admin = () => {
     const [openMenu, setOpenMenu] = useState(false);
     const navigate = useNavigate();
-    const auth = useAuth();
     const toggleDrawer = (newOpen: boolean) => () => {
         setOpenMenu(newOpen);
     };
@@ -62,12 +59,6 @@ const Admin = () => {
             <Divider/>
         </Box>
     );
-    useEffect(() => {
-        if (auth.isAuthLoading) return;
-        if (!auth.isAdmin || !auth.isSignedIn) {
-            navigate('/auth/sign-in');
-        }
-    }, [auth.isAuthLoading, auth.isAdmin, auth.isSignedIn, navigate])
 
     return (
         <>

--- a/src/pages/Admin/CategoryCrud.tsx
+++ b/src/pages/Admin/CategoryCrud.tsx
@@ -3,7 +3,7 @@ import {useState} from "react";
 import {useEffect} from "react";
 import LpBackdrop from "../../components/LpBackdrop/LpBackdrop.tsx";
 import LpListReorderDialog from "../../components/LpList/LpListReorderDialog.tsx";
-import apiClient from "../../http";
+import {apiClient} from "../../http";
 import IAction from "../../interfaces/IAction.ts";
 import ICategory from "../../interfaces/ICategory.ts";
 import CrudAdminBase from "./components/CrudAdminBase.tsx";

--- a/src/pages/Admin/MenuItemCrud.tsx
+++ b/src/pages/Admin/MenuItemCrud.tsx
@@ -5,7 +5,7 @@ import {useState} from "react";
 import {useEffect} from "react";
 import LpBackdrop from "../../components/LpBackdrop/LpBackdrop.tsx";
 import GridCellExpand from "../../components/LpDataGrid/GridCellExpand.tsx";
-import apiClient from "../../http";
+import {apiClient} from "../../http";
 import IAction from "../../interfaces/IAction.ts";
 import IMenuItem from "../../interfaces/IMenuItem.ts";
 import ITag from "../../interfaces/ITag.ts";

--- a/src/pages/Admin/TagCrud.tsx
+++ b/src/pages/Admin/TagCrud.tsx
@@ -2,7 +2,7 @@ import {GridColDef} from "@mui/x-data-grid";
 import {useState} from "react";
 import {useEffect} from "react";
 import LpBackdrop from "../../components/LpBackdrop/LpBackdrop.tsx";
-import apiClient from "../../http";
+import {apiClient} from "../../http";
 import IAction from "../../interfaces/IAction.ts";
 import ITag from "../../interfaces/ITag.ts";
 import CrudAdminBase from "./components/CrudAdminBase.tsx";

--- a/src/pages/Admin/components/CrudAdminBase.tsx
+++ b/src/pages/Admin/components/CrudAdminBase.tsx
@@ -95,7 +95,7 @@ const CrudAdminBase = (props: ICrudAdminBaseProps) => {
                 rows={rows}
                 slots={{
                     toolbar: () => DataGridToolBar({
-                        gridTitle: label, addButtonToolTip: "Add new item", reorderButtonToolTip: "Change items order", onClick: handleOpenForm, showFilter: true
+                        gridTitle: label, addButtonToolTip: "Add new item", reorderButtonToolTip: "Change items order", onClick: handleOpenForm, showFilter: true, reorder: reorder
                     })
                 }}
                 showToolbar

--- a/src/pages/Admin/components/LpDeleteDialog.tsx
+++ b/src/pages/Admin/components/LpDeleteDialog.tsx
@@ -4,7 +4,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import LpButton from "../../../components/LpButton/LpButton.tsx";
-import apiClient from "../../../http";
+import {apiClient} from "../../../http";
 import IAction from "../../../interfaces/IAction.ts";
 import {useCrudAdminContext} from "../context/CrudAdminContext.ts";
 

--- a/src/pages/Admin/hooks/useCategoryDialogForm.ts
+++ b/src/pages/Admin/hooks/useCategoryDialogForm.ts
@@ -6,7 +6,7 @@ import {UseFormHandleSubmit} from "react-hook-form";
 import {Control} from "react-hook-form";
 import {useForm} from "react-hook-form";
 
-import apiClient from "../../../http";
+import {apiClient} from "../../../http";
 import IAction from "../../../interfaces/IAction.ts";
 import IAlert from "../../../interfaces/IAlert.ts";
 import ICategory from "../../../interfaces/ICategory.ts";

--- a/src/pages/Admin/hooks/useMenuItemDialogForm.ts
+++ b/src/pages/Admin/hooks/useMenuItemDialogForm.ts
@@ -6,7 +6,7 @@ import {UseFormHandleSubmit} from "react-hook-form";
 import {Control} from "react-hook-form";
 import {useForm} from "react-hook-form";
 
-import apiClient from "../../../http";
+import {apiClient} from "../../../http";
 import IAction from "../../../interfaces/IAction.ts";
 import IAlert from "../../../interfaces/IAlert.ts";
 import ICategory from "../../../interfaces/ICategory.ts";

--- a/src/pages/Admin/hooks/useTagDialogForm.ts
+++ b/src/pages/Admin/hooks/useTagDialogForm.ts
@@ -6,7 +6,7 @@ import {UseFormHandleSubmit} from "react-hook-form";
 import {Control} from "react-hook-form";
 import {useForm} from "react-hook-form";
 
-import apiClient from "../../../http";
+import {apiClient} from "../../../http";
 import IAction from "../../../interfaces/IAction.ts";
 import IAlert from "../../../interfaces/IAlert.ts";
 import ITag from "../../../interfaces/ITag.ts";

--- a/src/pages/Auth/SignIn.tsx
+++ b/src/pages/Auth/SignIn.tsx
@@ -12,10 +12,9 @@ import Alert from "@mui/material/Alert";
 import Collapse from "@mui/material/Collapse";
 
 import LpButton from "../../components/LpButton/LpButton.tsx";
-import {ChangeEvent, FormEvent, useEffect, useState} from "react";
+import {ChangeEvent, FormEvent, useState} from "react";
 import {useAuth} from "../../context/auth/AuthContext.ts";
 import ResetPassword from "./ResetPassword.tsx";
-import {useNavigate} from "react-router";
 import {AxiosError} from "axios";
 
 
@@ -38,8 +37,7 @@ const SignIn = () => {
     const [passwordErrorMsg, setPasswordErrorMsg] = useState('');
 
 
-    const {isSignedIn, isAuthLoading, login} = useAuth();
-    const navigate = useNavigate();
+    const {isAuthLoading, login} = useAuth();
 
     const handleClickOpen = () => {
         setOpen(true);
@@ -55,15 +53,13 @@ const SignIn = () => {
         setPasswordError(false);
         setPasswordErrorMsg('')
     }
+
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         clearErrors();
         try {
             await login(email, password);
-            // navigation handled by the existing useEffect on isSignedIn,
-            // OR navigate explicitly here — your choice.
         } catch (error) {
-            // keep the existing error-mapping block, but read from `err`
             if (error instanceof AxiosError && error.response) {
                 const data = error.response.data;
                 if (error.response.status === 400) {
@@ -151,11 +147,7 @@ const SignIn = () => {
         //     })
 
     }
-    useEffect(() => {
-        if (isSignedIn) {
-            navigate('/');
-        }
-    }, [isSignedIn, navigate])
+
     return (
         <>
             <Typography

--- a/src/pages/Auth/SignIn.tsx
+++ b/src/pages/Auth/SignIn.tsx
@@ -15,9 +15,8 @@ import LpButton from "../../components/LpButton/LpButton.tsx";
 import {ChangeEvent, FormEvent, useEffect, useState} from "react";
 import {useAuth} from "../../context/auth/AuthContext.ts";
 import ResetPassword from "./ResetPassword.tsx";
-import apiClient from "../../http";
 import {useNavigate} from "react-router";
-import IUser from "../../interfaces/IUser.ts";
+import {AxiosError} from "axios";
 
 
 const StyledTextField = styled(TextField)({
@@ -39,7 +38,7 @@ const SignIn = () => {
     const [passwordErrorMsg, setPasswordErrorMsg] = useState('');
 
 
-    const {isSignedIn, setIsSignedIn, setIsAdmin} = useAuth();
+    const {isSignedIn, isAuthLoading, login} = useAuth();
     const navigate = useNavigate();
 
     const handleClickOpen = () => {
@@ -56,71 +55,107 @@ const SignIn = () => {
         setPasswordError(false);
         setPasswordErrorMsg('')
     }
-    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-        clearErrors();
-        const payload = {
-            email: email,
-            password: password
-        }
-
-        apiClient.post('/auth/sign-in/', payload)
-            .then(res => {
-                sessionStorage.setItem('token', res.data.access);
-                sessionStorage.setItem('refresh', res.data.refresh);
-                setEmail('');
-                setPassword('');
-                setIsSignedIn(true);
-                const jwtPayload = JSON.parse(atob(res.data.access.split('.')[1]));
-                if (jwtPayload) {
-                    if ('admin' in jwtPayload) {
-                        setIsAdmin(jwtPayload.admin);
-                    } else {
-                        setIsAdmin(false);
-                    }
-
-                } else {
-                    setIsAdmin(false);
-                }
-            })
-            .then(() => {
-                apiClient.get<IUser>('/auth/users/me/')
-                    .then(res => {
-                        sessionStorage.setItem('user', JSON.stringify(res.data));
-                    })
-                    .catch(err => {
-                            console.log(err);
-                        }
-                    )
-            })
-            .catch(err => {
-                if (err.response) {
-                    const data = err.response.data;
-                    if (err.response.status === 400) {
-                        if (data.email) {
-                            setEmailError(true);
-                            setEmailErrorMsg(() => (data.email));
-                        }
-                        if (data.password) {
-                            setPasswordError(true);
-                            setPasswordErrorMsg(() => (data.password));
-                        }
-                    } else {
-                        setAlertMessage(() => (data.detail));
-                        setAlertOpen(true);
-                    }
-                } else {
-                    setAlertOpen(true);
-                    setAlertMessage('Something went wrong. Please try again later or contact support.')
-                }
-
-            })
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
+        clearErrors();
+        try {
+            await login(email, password);
+            // navigation handled by the existing useEffect on isSignedIn,
+            // OR navigate explicitly here — your choice.
+        } catch (error) {
+            // keep the existing error-mapping block, but read from `err`
+            if (error instanceof AxiosError && error.response) {
+                const data = error.response.data;
+                if (error.response.status === 400) {
+                    if (data.email) {
+                        setEmailError(true);
+                        setEmailErrorMsg(data.email);
+                    }
+                    if (data.password) {
+                        setPasswordError(true);
+                        setPasswordErrorMsg(data.password);
+                    }
+                } else {
+                    setAlertMessage(data.detail);
+                    setAlertOpen(true);
+                }
+            } else {
+                setAlertOpen(true);
+                setAlertMessage('Something went wrong. Please try again later or contact support.');
+            }
+        }
+        // try {
+        //     await login(email, password);
+        //     navigate('/');
+        // } catch (error) {
+        //     console.log(error)
+        // }
+        // const payload = {
+        //     email: email,
+        //     password: password
+        // }
+        //
+        // apiClient.post('/auth/sign-in/', payload)
+        //     .then(res => {
+        //         tokenStore.setAccess(res.data.access)
+        //         tokenStore.setRefresh(res.data.refresh)
+        //         setEmail('');
+        //         setPassword('');
+        //         // setIsSignedIn(true);
+        //         const jwtPayload = JSON.parse(atob(res.data.access.split('.')[1]));
+        //         if (jwtPayload) {
+        //             if ('admin' in jwtPayload) {
+        //                 // setIsAdmin(jwtPayload.admin);
+        //                 console.log("is admin")
+        //             } else {
+        //                 // setIsAdmin(false);
+        //                 console.log("is not admin")
+        //             }
+        //
+        //         } else {
+        //             // setIsAdmin(false);
+        //             console.log("jwt payload is null")
+        //         }
+        //     })
+        //     .then(() => {
+        //         apiClient.get<IUser>('/auth/users/me/')
+        //             .then(res => {
+        //                 sessionStorage.setItem('user', JSON.stringify(res.data));
+        //             })
+        //             .catch(err => {
+        //                     console.log(err);
+        //                 }
+        //             )
+        //     })
+        //     .catch(err => {
+        //         if (err.response) {
+        //             const data = err.response.data;
+        //             if (err.response.status === 400) {
+        //                 if (data.email) {
+        //                     setEmailError(true);
+        //                     setEmailErrorMsg(() => (data.email));
+        //                 }
+        //                 if (data.password) {
+        //                     setPasswordError(true);
+        //                     setPasswordErrorMsg(() => (data.password));
+        //                 }
+        //             } else {
+        //                 setAlertMessage(() => (data.detail));
+        //                 setAlertOpen(true);
+        //             }
+        //         } else {
+        //             setAlertOpen(true);
+        //             setAlertMessage('Something went wrong. Please try again later or contact support.')
+        //         }
+        //
+        //     })
+
     }
     useEffect(() => {
         if (isSignedIn) {
             navigate('/');
         }
-    })
+    }, [isSignedIn, navigate])
     return (
         <>
             <Typography
@@ -184,11 +219,12 @@ const SignIn = () => {
                     label="Remember me"/>
 
                 <LpButton
+                    disabled={isAuthLoading}
                     type="submit"
                     fullWidth
                     // onClick={validateInputs}
                     variant="contained">
-                Sign in
+                    Sign in
                 </LpButton>
 
                 <Link

--- a/src/pages/Auth/SignIn.tsx
+++ b/src/pages/Auth/SignIn.tsx
@@ -1,44 +1,27 @@
 import Box from "@mui/material/Box";
 import Checkbox from "@mui/material/Checkbox";
 import Divider from "@mui/material/Divider"
-import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
-import FormLabel from "@mui/material/FormLabel";
-import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
-import {styled} from "@mui/material/styles";
-import Alert from "@mui/material/Alert";
-import Collapse from "@mui/material/Collapse";
-
 import LpButton from "../../components/LpButton/LpButton.tsx";
-import {ChangeEvent, FormEvent, useState} from "react";
+import {useState} from "react";
 import {useAuth} from "../../context/auth/AuthContext.ts";
 import ResetPassword from "./ResetPassword.tsx";
-import {AxiosError} from "axios";
+import {SignInSchema} from "./types/AuthSchema.ts";
+import useSignInForm from "./hooks/useSignInForm.ts";
+import LpTextField from "../../components/LpTextField/LpTextField.tsx";
+import LpBackdrop from "../../components/LpBackdrop/LpBackdrop.tsx";
 
-
-const StyledTextField = styled(TextField)({
-    '& .MuiInputBase-input': {
-        boxSizing: 'border-box',
-    }
-})
 
 const SignIn = () => {
+
+    const {control, alertState, handleSubmit, onSubmit, hideAlert} = useSignInForm();
+    const {isAuthLoading} = useAuth();
+
+    //===============================================================
+    // Temporary state and handlers for reset password modal
     const [open, setOpen] = useState(false);
-    const [alertOpen, setAlertOpen] = useState(false);
-    const [alertMessage, setAlertMessage] = useState('');
-
-    const [email, setEmail] = useState('');
-    const [password, setPassword] = useState('');
-    const [emailError, setEmailError] = useState(false);
-    const [emailErrorMsg, setEmailErrorMsg] = useState('');
-    const [passwordError, setPasswordError] = useState(false);
-    const [passwordErrorMsg, setPasswordErrorMsg] = useState('');
-
-
-    const {isAuthLoading, login} = useAuth();
-
     const handleClickOpen = () => {
         setOpen(true);
     };
@@ -46,108 +29,7 @@ const SignIn = () => {
     const handleClose = () => {
         setOpen(false);
     };
-    const clearErrors = () => {
-        setAlertOpen(false);
-        setEmailError(false);
-        setEmailErrorMsg('');
-        setPasswordError(false);
-        setPasswordErrorMsg('')
-    }
-
-    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        clearErrors();
-        try {
-            await login(email, password);
-        } catch (error) {
-            if (error instanceof AxiosError && error.response) {
-                const data = error.response.data;
-                if (error.response.status === 400) {
-                    if (data.email) {
-                        setEmailError(true);
-                        setEmailErrorMsg(data.email);
-                    }
-                    if (data.password) {
-                        setPasswordError(true);
-                        setPasswordErrorMsg(data.password);
-                    }
-                } else {
-                    setAlertMessage(data.detail);
-                    setAlertOpen(true);
-                }
-            } else {
-                setAlertOpen(true);
-                setAlertMessage('Something went wrong. Please try again later or contact support.');
-            }
-        }
-        // try {
-        //     await login(email, password);
-        //     navigate('/');
-        // } catch (error) {
-        //     console.log(error)
-        // }
-        // const payload = {
-        //     email: email,
-        //     password: password
-        // }
-        //
-        // apiClient.post('/auth/sign-in/', payload)
-        //     .then(res => {
-        //         tokenStore.setAccess(res.data.access)
-        //         tokenStore.setRefresh(res.data.refresh)
-        //         setEmail('');
-        //         setPassword('');
-        //         // setIsSignedIn(true);
-        //         const jwtPayload = JSON.parse(atob(res.data.access.split('.')[1]));
-        //         if (jwtPayload) {
-        //             if ('admin' in jwtPayload) {
-        //                 // setIsAdmin(jwtPayload.admin);
-        //                 console.log("is admin")
-        //             } else {
-        //                 // setIsAdmin(false);
-        //                 console.log("is not admin")
-        //             }
-        //
-        //         } else {
-        //             // setIsAdmin(false);
-        //             console.log("jwt payload is null")
-        //         }
-        //     })
-        //     .then(() => {
-        //         apiClient.get<IUser>('/auth/users/me/')
-        //             .then(res => {
-        //                 sessionStorage.setItem('user', JSON.stringify(res.data));
-        //             })
-        //             .catch(err => {
-        //                     console.log(err);
-        //                 }
-        //             )
-        //     })
-        //     .catch(err => {
-        //         if (err.response) {
-        //             const data = err.response.data;
-        //             if (err.response.status === 400) {
-        //                 if (data.email) {
-        //                     setEmailError(true);
-        //                     setEmailErrorMsg(() => (data.email));
-        //                 }
-        //                 if (data.password) {
-        //                     setPasswordError(true);
-        //                     setPasswordErrorMsg(() => (data.password));
-        //                 }
-        //             } else {
-        //                 setAlertMessage(() => (data.detail));
-        //                 setAlertOpen(true);
-        //             }
-        //         } else {
-        //             setAlertOpen(true);
-        //             setAlertMessage('Something went wrong. Please try again later or contact support.')
-        //         }
-        //
-        //     })
-
-    }
-
+    //===============================================================
     return (
         <>
             <Typography
@@ -156,12 +38,9 @@ const SignIn = () => {
                 sx={{width: '100%', fontSize: 'clamp(2rem, 10vw, 2.15rem)'}}>
                 Sign in
             </Typography>
-            <Collapse in={alertOpen}>
-                <Alert severity="error">{alertMessage}</Alert>
-            </Collapse>
             <Box
                 component="form"
-                onSubmit={handleSubmit}
+                onSubmit={handleSubmit(onSubmit)}
                 noValidate
                 sx={{
                     display: 'flex',
@@ -169,43 +48,10 @@ const SignIn = () => {
                     width: '100%',
                     gap: 2,
                 }}>
-                <FormControl>
-                    <FormLabel htmlFor="email">Email</FormLabel>
-                    <StyledTextField
-                        id="email"
-                        type="email"
-                        name="email"
-                        placeholder="your@email.com"
-                        autoComplete="email"
-                        required
-                        variant="outlined"
-                        autoFocus
-                        value={email}
-                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                            setEmail(event.target.value);
-                        }}
-                        error={emailError}
-                        helperText={emailErrorMsg}
-                        color={emailError ? 'error' : 'primary'}/>
-                </FormControl>
-                <FormControl>
-                    <FormLabel htmlFor="password">Password</FormLabel>
-                    <StyledTextField
-                        id="password"
-                        type="password"
-                        name="password"
-                        placeholder="••••••"
-                        autoComplete="current-password"
-                        required
-                        variant="outlined"
-                        value={password}
-                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                            setPassword(event.target.value);
-                        }}
-                        error={passwordError}
-                        helperText={passwordErrorMsg}
-                        color={passwordError ? 'error' : 'primary'}/>
-                </FormControl>
+                <LpTextField<SignInSchema> control={control} id={"email"} name={"email"} label={"Email"} type={"email"}
+                                           defaultValue={""} variant="outlined"/>
+                <LpTextField<SignInSchema> control={control} id={"password"} name={"password"} label={"Password"}
+                                           type={"password"} defaultValue={""} variant="outlined"/>
                 <FormControlLabel
                     control={<Checkbox value="remember" color="primary"/>}
                     label="Remember me"/>
@@ -214,7 +60,6 @@ const SignIn = () => {
                     disabled={isAuthLoading}
                     type="submit"
                     fullWidth
-                    // onClick={validateInputs}
                     variant="contained">
                     Sign in
                 </LpButton>
@@ -249,6 +94,7 @@ const SignIn = () => {
                 </Typography>
             </Box>
             <ResetPassword open={open} handleClose={handleClose}/>
+            <LpBackdrop isLoading={isAuthLoading} alertState={alertState} closeAlert={hideAlert}/>
         </>
     )
 }

--- a/src/pages/Auth/SignUp.tsx
+++ b/src/pages/Auth/SignUp.tsx
@@ -14,7 +14,7 @@ import {styled} from "@mui/material/styles";
 import CircularProgress from '@mui/material/CircularProgress';
 import LpButton from "../../components/LpButton/LpButton.tsx";
 import {FormEvent, useState} from "react";
-import apiClient from "../../http";
+import {apiClient} from "../../http";
 import {useNavigate} from "react-router";
 
 

--- a/src/pages/Auth/SignUp.tsx
+++ b/src/pages/Auth/SignUp.tsx
@@ -105,7 +105,7 @@ const SignUp = () => {
                 component="h1"
                 variant="h4"
                 sx={{width: '100%', fontSize: 'clamp(2rem, 10vw, 2.15rem)'}}>
-                Sign up
+                Sign Up
             </Typography>
             <Collapse in={defaultError}>
                 <Alert severity="error">Something went wrong. Please try again later or contact support.</Alert>
@@ -197,7 +197,7 @@ const SignUp = () => {
                     fullWidth
                     // onClick={validateInputs}
                     variant="contained">
-                    Sign up
+                    Sign Up
                 </LpButton>
             </Box>
             <Divider>or</Divider>
@@ -212,7 +212,7 @@ const SignUp = () => {
                             color: 'var(--tertiary-color)',
                             opacity: 0.65,
                         }}>
-                        Sign in
+                        Sign In
                     </Link>
                 </Typography>
             </Box>

--- a/src/pages/Auth/hooks/useSignInForm.ts
+++ b/src/pages/Auth/hooks/useSignInForm.ts
@@ -1,0 +1,72 @@
+import {Control, useForm, UseFormHandleSubmit} from "react-hook-form";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {signInDefaultValues, signInSchema, SignInSchema} from "../types/AuthSchema.ts";
+import {isAxiosError} from "axios";
+import {useAuth} from "../../../context/auth/AuthContext.ts";
+import {useCallback, useState} from "react";
+import IAlert from "../../../interfaces/IAlert.ts";
+import {AlertColor} from "@mui/material/Alert";
+
+
+interface ISignInFormReturn {
+    // Form controls
+    control: Control<SignInSchema>;
+    handleSubmit: UseFormHandleSubmit<SignInSchema>;
+
+    // States
+    alertState: IAlert;
+
+    // Handlers
+    onSubmit: (data: SignInSchema) => void;
+    showAlert: (message: string, severity?: AlertColor) => void;
+    hideAlert: () => void;
+}
+
+const useSignInForm = (): ISignInFormReturn => {
+    const {signIn} = useAuth();
+
+    const [alertState, setAlertState] = useState<IAlert>({
+        open: false,
+        severity: "error",
+        message: "",
+    })
+
+    // Form setup
+    const {control, handleSubmit} = useForm<SignInSchema>({
+        mode: "onBlur", resolver: zodResolver(signInSchema), defaultValues: signInDefaultValues,
+    });
+
+    const showAlert = useCallback((message: string, severity: AlertColor = "error") => {
+        setAlertState({open: true, severity, message});
+    }, []);
+
+    const hideAlert = useCallback(() => {
+        setAlertState(prevState => ({...prevState, open: false}));
+    }, []);
+
+    const onSubmit = async (data: SignInSchema) => {
+        hideAlert();
+        try {
+            await signIn(data.email, data.password);
+        } catch (error) {
+            if (isAxiosError(error) && error.response?.status === 401) {
+                showAlert("Invalid Email or Password", "error");
+            } else {
+                showAlert("Something went wrong. Please try again later or contact support.", "error");
+            }
+        }
+    };
+
+    return {
+        // Form controls
+        control, handleSubmit,
+
+        // States
+        alertState,
+
+        // Handlers
+        onSubmit, hideAlert, showAlert
+    };
+};
+
+export default useSignInForm;

--- a/src/pages/Auth/types/AuthSchema.ts
+++ b/src/pages/Auth/types/AuthSchema.ts
@@ -1,0 +1,36 @@
+import * as z from 'zod';
+
+
+const signInSchema = z.object({
+    email: z.email(),
+    password: z.string().min(1, {message: 'Password is required'})
+});
+
+const signUpSchema = z.object({
+    email: z.email(),
+    password: z.string().min(6, {message: 'Password must be at least 6 characters long'}),
+    first_name: z.string().min(2, {message: 'Name must be at least 2 characters long'}),
+    last_name: z.string().min(2, {message: 'Name must be at least 2 characters long'}),
+});
+
+const signInDefaultValues = {
+    email: '',
+    password: ''
+};
+
+const signUpDefaultValues = {
+    email: '',
+    password: '',
+    first_name: '',
+    last_name: ''
+};
+
+export {
+    signInSchema,
+    signUpSchema,
+    signInDefaultValues,
+    signUpDefaultValues
+};
+
+export type SignInSchema = z.infer<typeof signInSchema>;
+export type SignUpSchema = z.infer<typeof signUpSchema>;

--- a/src/pages/Menu/Menu.tsx
+++ b/src/pages/Menu/Menu.tsx
@@ -12,8 +12,10 @@ import ICategory from "../../interfaces/ICategory.ts";
 const RestaurantMenu = () => {
     const [categories, setCategories] = useState<ICategory[]>([]);
     const [selectedTab, setSelectedTab] = useState<number>(0);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
 
     useEffect(() => {
+        setIsLoading(true);
         apiClient.get<ICategory[]>('/api/v1/category/menu-items')
             .then(response => {
                 setCategories(response.data);
@@ -22,6 +24,7 @@ const RestaurantMenu = () => {
                     console.log(error);
                 }
             )
+            .finally(() => setIsLoading(false));
     }, [])
     return (
         <>
@@ -44,7 +47,7 @@ const RestaurantMenu = () => {
                 </Tabs>
 
 
-                {!categories.length && <Box sx={{
+                {!isLoading && !categories.length && <Box sx={{
                     textAlign: "center",
                 }}>
                     <LpImage src={"https://storage.googleapis.com/little-pequi/assets/under_construction.jpg"} alt="Page Under Construction"/>

--- a/src/pages/Menu/Menu.tsx
+++ b/src/pages/Menu/Menu.tsx
@@ -6,7 +6,7 @@ import Typography from "@mui/material/Typography";
 import {useEffect, useState} from "react";
 import LpCard from "../../components/LpCard/LpCard.tsx";
 import LpImage from "../../components/LpImage/LpImage.tsx";
-import apiClient from "../../http";
+import {apiClient} from "../../http";
 import ICategory from "../../interfaces/ICategory.ts";
 
 const RestaurantMenu = () => {

--- a/src/pages/User/UserAccount.tsx
+++ b/src/pages/User/UserAccount.tsx
@@ -4,11 +4,12 @@ import {useEffect} from "react";
 import {useState} from "react";
 import {useNavigate} from "react-router";
 import IUser from "../../interfaces/IUser.ts";
+import {tokenStore} from "../../http/auth.ts";
 
 const UserAccount = () => {
 
     const [userObj, setUserObj] = useState<null | IUser>(null)
-    const user = sessionStorage.getItem('user')
+    const user = tokenStore.getUser()
     const navigate = useNavigate();
 
     useEffect(() => {

--- a/src/pages/User/UserAccount.tsx
+++ b/src/pages/User/UserAccount.tsx
@@ -1,32 +1,18 @@
 import Container from "@mui/material/Container"
 import Typography from "@mui/material/Typography";
-import {useEffect} from "react";
-// import {useState} from "react";
-import {useNavigate} from "react-router";
-// import IUser from "../../interfaces/IUser.ts";
 import {useAuth} from "../../context/auth/AuthContext.ts";
 
 const UserAccount = () => {
 
-    // const [userObj, setUserObj] = useState<null | IUser>(null)
     const {user} = useAuth();
-    const navigate = useNavigate();
-    //
-    useEffect(() => {
-        if (user === null) {
-            navigate('/')
-        }
-        //     } else {
-        //         setUserObj(user)
-        //     }
-    }, [user, navigate])
-
 
     return (
         <>
             <Container>
                 <Typography variant={"h1"}>{`${user?.first_name} ${user?.last_name}`}</Typography>
             </Container>
+
+
         </>
     );
 };

--- a/src/pages/User/UserAccount.tsx
+++ b/src/pages/User/UserAccount.tsx
@@ -1,30 +1,31 @@
 import Container from "@mui/material/Container"
 import Typography from "@mui/material/Typography";
 import {useEffect} from "react";
-import {useState} from "react";
+// import {useState} from "react";
 import {useNavigate} from "react-router";
-import IUser from "../../interfaces/IUser.ts";
-import {tokenStore} from "../../http/auth.ts";
+// import IUser from "../../interfaces/IUser.ts";
+import {useAuth} from "../../context/auth/AuthContext.ts";
 
 const UserAccount = () => {
 
-    const [userObj, setUserObj] = useState<null | IUser>(null)
-    const user = tokenStore.getUser()
+    // const [userObj, setUserObj] = useState<null | IUser>(null)
+    const {user} = useAuth();
     const navigate = useNavigate();
-
+    //
     useEffect(() => {
         if (user === null) {
             navigate('/')
-        } else {
-            setUserObj(JSON.parse(user))
         }
+        //     } else {
+        //         setUserObj(user)
+        //     }
     }, [user, navigate])
 
 
     return (
         <>
             <Container>
-                <Typography variant={"h1"}>{`${userObj?.first_name} ${userObj?.last_name}`}</Typography>
+                <Typography variant={"h1"}>{`${user?.first_name} ${user?.last_name}`}</Typography>
             </Container>
         </>
     );

--- a/src/routes/RedirectIfSignedIn.tsx
+++ b/src/routes/RedirectIfSignedIn.tsx
@@ -4,9 +4,9 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Backdrop from "@mui/material/Backdrop";
 
 export const RedirectIfSignedIn = ({to = "/"}: { to?: string }) => {
-    const {isSignedIn, isAuthLoading} = useAuth();
+    const {isSignedIn, isBootstrapping} = useAuth();
     const location = useLocation();
-    if (isAuthLoading) {
+    if (isBootstrapping) {
         return (
             <>
                 <Backdrop open={true} sx={{color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1}}>

--- a/src/routes/RedirectIfSignedIn.tsx
+++ b/src/routes/RedirectIfSignedIn.tsx
@@ -1,0 +1,23 @@
+import {useAuth} from "../context/auth/AuthContext.ts";
+import {Navigate, Outlet, useLocation} from "react-router";
+import CircularProgress from "@mui/material/CircularProgress";
+import Backdrop from "@mui/material/Backdrop";
+
+export const RedirectIfSignedIn = ({to = "/"}: { to?: string }) => {
+    const {isSignedIn, isAuthLoading} = useAuth();
+    const location = useLocation();
+    if (isAuthLoading) {
+        return (
+            <>
+                <Backdrop open={true} sx={{color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1}}>
+                    <CircularProgress color="inherit"/>
+                </Backdrop>
+
+            </>
+        );
+    }
+    if (isSignedIn) return <Navigate to={location.state && location.state.from ? location.state.from.pathname : to}
+                                     replace/>
+
+    return <Outlet/>
+}

--- a/src/routes/RequireAuth.tsx
+++ b/src/routes/RequireAuth.tsx
@@ -13,10 +13,10 @@ export const RequireAuth = ({
                                 adminOnly = false,
                                 redirectTo = "/auth/sign-in"
                             }: IRequireAuthProps) => {
-    const {isAuthLoading, isSignedIn, isAdmin} = useAuth();
+    const {isBootstrapping, isSignedIn, isAdmin} = useAuth();
     const location = useLocation();
 
-    if (isAuthLoading) {
+    if (isBootstrapping) {
         return (
             <>
                 <Backdrop open={true} sx={{color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1}}>
@@ -26,6 +26,7 @@ export const RequireAuth = ({
         );
     }
     if (!isSignedIn) return <Navigate to={redirectTo} replace state={{from: location}}/>;
+    {/*This is a UI hint! Backend enforces admin endpoints.*/}
     if (adminOnly && !isAdmin) return <Navigate to={"/"} replace/>;
 
 

--- a/src/routes/RequireAuth.tsx
+++ b/src/routes/RequireAuth.tsx
@@ -1,0 +1,36 @@
+import {Navigate, Outlet, useLocation} from "react-router";
+import {useAuth} from "../context/auth/AuthContext.ts";
+import CircularProgress from "@mui/material/CircularProgress";
+import Backdrop from "@mui/material/Backdrop";
+
+interface IRequireAuthProps {
+    adminOnly?: boolean;
+    redirectTo?: string;
+}
+
+
+export const RequireAuth = ({
+                                adminOnly = false,
+                                redirectTo = "/auth/sign-in"
+                            }: IRequireAuthProps) => {
+    const {isAuthLoading, isSignedIn, isAdmin} = useAuth();
+    const location = useLocation();
+
+    if (isAuthLoading) {
+        return (
+            <>
+                <Backdrop open={true} sx={{color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1}}>
+                    <CircularProgress color="inherit"/>
+                </Backdrop>
+            </>
+        );
+    }
+    if (!isSignedIn) return <Navigate to={redirectTo} replace state={{from: location}}/>;
+    if (adminOnly && !isAdmin) return <Navigate to={"/"} replace/>;
+
+
+    return <Outlet/>;
+}
+
+export default RequireAuth;
+

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -16,31 +16,44 @@ import Reservations from "../pages/Reservations";
 import BaseUserPage from "../pages/User/BaseUserPage.tsx";
 import UserAccount from "../pages/User/UserAccount.tsx";
 import UserOrder from "../pages/User/UserOrder.tsx";
+import RequireAuth from "./RequireAuth.tsx";
+import {RedirectIfSignedIn} from "./RedirectIfSignedIn.tsx";
 
 function LpRoutes() {
     return (
         <Routes>
+            {/* Public routes */}
             <Route path="/" element={<BasePage/>}>
-                <Route path="/" element={<Home/>}/>
-                <Route path="/auth" element={<BaseAuthPage/>}>
-                    <Route path="sign-in" element={<SignIn/>}/>
-                    <Route path="sign-up" element={<SignUp/>}/>
-                </Route>
-                <Route path="/about" element={<About/>}/>
-                <Route path="/menu" element={<RestaurantMenu/>}/>
-                <Route path="/reservations" element={<Reservations/>}/>
-                <Route path="/order" element={<MakeOrder/>}/>
-                <Route path="/user" element={<BaseUserPage/>}>
-                    <Route path="admin" element={<Admin/>}>
-                        <Route index element={<Dashboard/>}/>
-                        <Route path="category" element={<CategoryCrud/>}/>
-                        <Route path="tag" element={<TagCrud/>}/>
-                        <Route path="menu-item" element={<MenuItemCrud/>}/>
+                <Route index element={<Home/>}/>
+                <Route path="about" element={<About/>}/>
+                <Route path="menu" element={<RestaurantMenu/>}/>
+                <Route path="reservations" element={<Reservations/>}/>
+                <Route path="order" element={<MakeOrder/>}/>
+
+                <Route element={<RedirectIfSignedIn/>}>
+                    <Route path="auth" element={<BaseAuthPage/>}>
+                        <Route path="sign-in" element={<SignIn/>}/>
+                        <Route path="sign-up" element={<SignUp/>}/>
                     </Route>
-                    <Route path="account" element={<UserAccount/>}/>
-                    <Route path="order" element={<UserOrder/>}/>
                 </Route>
 
+                {/* Sign-in required routes */}
+                <Route element={<RequireAuth/>}>
+                    <Route path="user" element={<BaseUserPage/>}>
+                        <Route path="account" element={<UserAccount/>}/>
+                        <Route path="order" element={<UserOrder/>}/>
+
+                        {/* Admin-only routes */}
+                        <Route element={<RequireAuth adminOnly/>}>
+                            <Route path="admin" element={<Admin/>}>
+                                <Route index element={<Dashboard/>}/>
+                                <Route path="category" element={<CategoryCrud/>}/>
+                                <Route path="tag" element={<TagCrud/>}/>
+                                <Route path="menu-item" element={<MenuItemCrud/>}/>
+                            </Route>
+                        </Route>
+                    </Route>
+                </Route>
             </Route>
         </Routes>
     )


### PR DESCRIPTION
## Summary

Rewrites the login system to fix security and correctness issues in the previous flow, and centralizes auth state in `AuthContext` as the single source of truth.

## What changed

### Auth state and context (`src/context/auth/`)
- `AuthContext` now exposes `user`, `isSignedIn`, `isAdmin`, `isBootstrapping`, `isAuthLoading`, `signIn`, `signOut`. Raw setters removed.
- `AuthContextProvider` owns the entire auth state machine: sign-in, sign-out, bootstrap via `refreshClient.post('/auth/refresh/')` + `/auth/users/me/`, cross-tab sign-out via `BroadcastChannel`.
- `isBootstrapping` and `isAuthLoading` are split so an in-flight `signIn` doesn't unmount the sign-in form (which was destroying alert state).
- `isAdmin` derived from server-verified `user.is_staff` instead of a client-decoded JWT claim.

### Token / JWT plumbing (`src/http/`)
- **Access token now lives in memory** (module-level variable inside `tokenStore`) and no longer in `sessionStorage`. XSS payloads can no longer read it from storage.
- **Refresh token moved to an `HttpOnly` cookie** managed by the backend.
- Both axios instances use `withCredentials: true` so the refresh cookie is auto-attached.
- `refreshClient` (a dedicated interceptor-free axios instance) sends `X-Requested-With: XMLHttpRequest` on `/auth/refresh/` as a defense-in-depth against CSRF.
- Refresh flow reads no body the cookie is the sole refresh credential.
- Refresh failure fires a `signOut` callback that resets React state instead of a hard `window.location` redirect to the wrong path.
- Response interceptor refreshes on 401 with a properly typed queue for concurrent requests.

### Route guards (`src/routes/`)
- New `<RequireAuth>` and `<RequireAuth adminOnly />` replace the `useEffect`-based redirects in `Admin.tsx`.
- New `<RedirectIfSignedIn>` bounces already-signed-in users away from `/auth/*` and honors `state.from` so post-login navigation returns to the originally requested URL.
- `routes/index.tsx` restructured so protected subtrees are declarative.

### Sign-in form (`src/pages/Auth/`)
- Form logic extracted into `useSignInForm` hook with `react-hook-form` + `zod` (`AuthSchema.ts`).
- Reusable Alert slot on the sign-in page — hook exposes `alert`, `showAlert(message, severity?)`, `hideAlert()` for any future flow.
- Generic error message for bad credentials (no field-level leak of which is wrong).

### Consumers updated
- `MenuUser`, `UserAccount`, `Admin`, `SignIn` all read from `useAuth()` instead of `sessionStorage`.
- `IUser` extended with `is_staff`.

## Backend contract (required for this PR to work)

- `POST /auth/sign-in/` — response body returns only `{ access }`; refresh token is set as `Set-Cookie: refresh=…; HttpOnly; Secure; SameSite=Strict; Path=/auth/`.
- `POST /auth/refresh/` — reads the `refresh` cookie (no request body); returns `{ access }` and rotates the cookie via a new `Set-Cookie`.
- `POST /auth/sign-out/` — clears the refresh cookie (`Set-Cookie: refresh=; Max-Age=0; Path=/auth/`) and blacklists the token.
- CORS on the backend must reflect the frontend origin explicitly and set `Access-Control-Allow-Credentials: true` (a wildcard origin is incompatible with credentialed requests).
